### PR TITLE
[Frontend] Minor sidebar refinements and cleanup

### DIFF
--- a/src/app/(organization)/layout.tsx
+++ b/src/app/(organization)/layout.tsx
@@ -50,17 +50,17 @@ const organizationData = {
       title: "Members",
       url: "/org-members",
       icon: "users",
-    },
-    {
-      title: "Reports",
-      url: "/organization/reports",
-      icon: "bar-chart",
-    },
-    {
-      title: "Settings",
-      url: "/organization/settings",
-      icon: "settings",
-    },
+    }
+    // {
+    //   title: "Reports",
+    //   url: "/organization/reports",
+    //   icon: "bar-chart",
+    // },
+    // {
+    //   title: "Settings",
+    //   url: "/organization/settings",
+    //   icon: "settings",
+    // },
   ],
   mobileNavLinks: [
     {

--- a/src/components/NavBar/app-sidebar.tsx
+++ b/src/components/NavBar/app-sidebar.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-"use client";
-
 import * as React from "react";
 import { LayoutDashboard, List, ChartBar } from "lucide-react";
 import { NavUser } from "./nav-user";
@@ -9,10 +6,7 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
+  SidebarLogo,
 } from "@/components/ui/sidebar";
 import Image from "next/image";
 import Link from "next/link";
@@ -32,7 +26,7 @@ interface NavItem {
 }
 
 interface IconMap {
-  [key: string]: React.ComponentType<any>;
+  [key: string]: React.ComponentType<{ className?: string }>;
 }
 
 interface AppSidebarProps {
@@ -59,36 +53,29 @@ export function AppSidebar({
   return (
     <Sidebar
       collapsible="offcanvas"
-      className={`bg-white border-r border-sidebar-border ${className || ""}`}
+      className={className}
       {...props}
     >
-      <SidebarHeader className="border-b border-sidebar-border/50">
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              className="hover:bg-sidebar-accent/20 transition-colors"
-            >
-              <Link href="/" className="flex items-center gap-2 p-4 py-6.5">
-                <Image
-                  src="/enhanced-logo-final.svg"
-                  alt=""
-                  width={36}
-                  height={36}
-                  className="text-primary"
-                />
-                <span className="text-3xl font-semibold text-primary">
-                  CORAL
-                </span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
-      <SidebarContent className="py-2">
+      <SidebarLogo>
+        <Link href="/" className="flex items-center justify-start space-x-4 w-full py-2">
+          <Image
+            src="/enhanced-logo-final.svg"
+            alt="CORAL Logo"
+            width={48}
+            height={48}
+            className="text-primary flex-shrink-0"
+          />
+          <div className="flex flex-col">
+            <span className="text-3xl font-bold text-gray-900 dark:text-white tracking-tight">
+              CORAL
+            </span>
+          </div>
+        </Link>
+      </SidebarLogo>
+      <SidebarContent>
         <NavMain items={navMain} iconMap={iconMap} />
       </SidebarContent>
-      <SidebarFooter className="border-t border-sidebar-border/50 mt-auto">
+      <SidebarFooter>
         <NavUser user={user} />
       </SidebarFooter>
     </Sidebar>

--- a/src/components/NavBar/nav-main.tsx
+++ b/src/components/NavBar/nav-main.tsx
@@ -7,6 +7,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { ComponentType } from "react";
 
@@ -26,24 +27,27 @@ interface NavMainProps {
 }
 
 export function NavMain({ items, iconMap }: NavMainProps) {
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  const handleNavClick = () => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+  };
+
   return (
     <SidebarGroup>
-      <SidebarGroupContent className="flex flex-col gap-1 px-2">
+      <SidebarGroupContent>
         <SidebarMenu>
           {items.map((item) => {
             const Icon =
               item.icon && iconMap[item.icon] ? iconMap[item.icon] : null;
             return (
               <SidebarMenuItem key={item.title}>
-                <Link href={item.url} className="w-full">
-                  <SidebarMenuButton
-                    tooltip={item.title}
-                    className="transition-colors py-2.5 hover:bg-sidebar-accent/20 data-[active=true]:bg-sidebar-accent/30 data-[active=true]:text-muted-foreground w-full"
-                  >
-                    {Icon && <Icon className="mr-3 text-muted-foreground/70" />}
-                    <span className="font-medium text-muted-foreground">
-                      {item.title}
-                    </span>
+                <Link href={item.url} className="w-full" onClick={handleNavClick}>
+                  <SidebarMenuButton tooltip={item.title}>
+                    {Icon && <Icon className="w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" />}
+                    <span>{item.title}</span>
                   </SidebarMenuButton>
                 </Link>
               </SidebarMenuItem>

--- a/src/components/NavBar/nav-user.tsx
+++ b/src/components/NavBar/nav-user.tsx
@@ -34,12 +34,16 @@ interface NavUserProps {
 }
 
 export function NavUser({ user }: NavUserProps) {
-  const { isMobile } = useSidebar();
+  const { isMobile, setOpenMobile } = useSidebar();
   const [isSigningOut, setIsSigningOut] = useState(false);
 
   const handleSignOut = async () => {
     try {
       setIsSigningOut(true);
+
+      if (isMobile) {
+        setOpenMobile(false);
+      }
 
       // Set global signing out state first
       cacheUtils.setSigningOut(true);
@@ -86,44 +90,44 @@ export function NavUser({ user }: NavUserProps) {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className="bg-primary-foreground text-primary hover:bg-primary/10 transition-all data-[state=open]:bg-primary/20 data-[state=open]:text-primary"
+              className="text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 data-[state=open]:bg-gray-100 dark:data-[state=open]:bg-gray-700"
             >
-              <Avatar className="h-8 w-8 rounded-lg border border-primary/20">
+              <Avatar className="h-9 w-9 rounded-lg">
                 <AvatarImage src={avatarSrc} alt={user.name} />
-                <AvatarFallback className="rounded-lg bg-primary/20 text-primary">
+                <AvatarFallback className="rounded-lg">
                   {user.name?.[0]?.toUpperCase() ?? "U"}
                 </AvatarFallback>
               </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium text-muted-foreground">
+              <div className="grid flex-1 text-left text-base leading-tight">
+                <span className="truncate font-semibold text-gray-900 dark:text-white">
                   {user.name}
                 </span>
-                <span className="truncate text-xs text-muted-foreground/70">
+                <span className="truncate text-sm text-gray-500 dark:text-gray-400">
                   {user.email}
                 </span>
               </div>
-              <MoreVertical className="ml-auto size-4 text-primary/70" />
+              <MoreVertical className="ml-auto size-5 text-gray-500 dark:text-gray-400" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg border-sidebar-border bg-primary-foreground"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
             side={isMobile ? "bottom" : "right"}
             align="end"
             sideOffset={4}
           >
             <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-2 py-2 text-left text-sm bg-primary/10 rounded-t-md">
-                <Avatar className="h-8 w-8 rounded-lg border border-primary/20">
+              <div className="flex items-center gap-3 px-3 py-3 text-left text-base">
+                <Avatar className="h-9 w-9 rounded-lg">
                   <AvatarImage src={avatarSrc} alt={user.name} />
-                  <AvatarFallback className="rounded-lg bg-primary/10 text-primary">
+                  <AvatarFallback className="rounded-lg">
                     {user.name?.[0]?.toUpperCase() ?? "U"}
                   </AvatarFallback>
                 </Avatar>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium text-muted-foreground">
+                <div className="grid flex-1 text-left text-base leading-tight">
+                  <span className="truncate font-semibold text-gray-900 dark:text-white">
                     {user.name}
                   </span>
-                  <span className="text-muted-foreground/70 truncate text-xs">
+                  <span className="text-gray-500 dark:text-gray-400 truncate text-sm">
                     {user.email}
                   </span>
                 </div>
@@ -132,10 +136,10 @@ export function NavUser({ user }: NavUserProps) {
             <DropdownMenuSeparator />
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              className="flex gap-2 py-1.5 text-destructive cursor-pointer"
+              className="flex gap-3 py-2.5 px-3 text-base text-destructive cursor-pointer hover:bg-red-50 dark:hover:bg-red-950/20"
               onClick={handleSignOut}
             >
-              <LogOut />
+              <LogOut className="size-5" />
               Log out
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -170,7 +170,7 @@ function Sidebar({
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          "bg-gray-50 dark:bg-gray-800 text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col border-r border-gray-200 dark:border-gray-700",
           className
         )}
         {...props}
@@ -187,7 +187,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="bg-gray-50 dark:bg-gray-800 text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden border-r border-gray-200 dark:border-gray-700"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -244,7 +244,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          className="bg-blue-80 dark:bg-gray-800 group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm border-r border-gray-200 dark:border-gray-700"
         >
           {children}
         </div>
@@ -266,7 +266,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
-      className={cn("size-10", className)}
+      className={cn("size-11 hover:bg-gray-100 dark:hover:bg-gray-700", className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
@@ -337,7 +337,21 @@ function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-header"
       data-sidebar="header"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarLogo({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-logo"
+      data-sidebar="logo"
+      className={cn(
+        "flex items-center justify-center px-6 py-5 bg-gray-50/50 dark:bg-gray-800/50",
+        className
+      )}
       {...props}
     />
   );
@@ -348,7 +362,7 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-footer"
       data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn("flex flex-col gap-2", className)}
       {...props}
     />
   );
@@ -374,7 +388,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-3 overflow-auto group-data-[collapsible=icon]:overflow-hidden px-4 py-5",
         className
       )}
       {...props}
@@ -387,7 +401,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col", className)}
       {...props}
     />
   );
@@ -405,7 +419,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground/70 ring-sidebar-ring flex h-9 shrink-0 items-center rounded-md px-3 text-sm font-semibold outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-5 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -426,7 +440,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-4 right-3 flex aspect-square w-6 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-5 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
@@ -456,7 +470,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      className={cn("flex w-full min-w-0 flex-col space-y-3 font-medium", className)}
       {...props}
     />
   );
@@ -474,18 +488,18 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-md p-3 text-left text-base outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:ring-2 active:bg-gray-100 dark:active:bg-gray-700 disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-gray-100 dark:data-[active=true]:bg-gray-700 data-[active=true]:font-semibold data-[active=true]:text-gray-900 dark:data-[active=true]:text-white data-[state=open]:hover:bg-gray-100 dark:data-[state=open]:hover:bg-gray-700 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-gray-900 dark:text-white",
   {
     variants: {
       variant: {
-        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        default: "hover:bg-blue-100 dark:hover:bg-gray-700",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-gray-100 dark:hover:bg-gray-700 hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))] text-gray-900 dark:text-white",
       },
       size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+        default: "h-10 text-base",
+        sm: "h-8 text-sm",
+        lg: "h-14 text-lg group-data-[collapsible=icon]:p-0!",
       },
     },
     defaultVariants: {
@@ -561,12 +575,12 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-2 right-2 flex aspect-square w-6 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-5 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
+        "peer-data-[size=default]/menu-button:top-2",
+        "peer-data-[size=lg]/menu-button:top-3",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
           "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
@@ -586,11 +600,11 @@ function SidebarMenuBadge({
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "text-sidebar-foreground pointer-events-none absolute right-2 flex h-6 min-w-6 items-center justify-center rounded-md px-2 text-sm font-semibold tabular-nums select-none",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
         "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
+        "peer-data-[size=default]/menu-button:top-2",
+        "peer-data-[size=lg]/menu-button:top-3",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -615,17 +629,17 @@ function SidebarMenuSkeleton({
     <div
       data-slot="sidebar-menu-skeleton"
       data-sidebar="menu-skeleton"
-      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      className={cn("flex h-10 items-center gap-3 rounded-md px-3", className)}
       {...props}
     >
       {showIcon && (
         <Skeleton
-          className="size-4 rounded-md"
+          className="size-5 rounded-md"
           data-sidebar="menu-skeleton-icon"
         />
       )}
       <Skeleton
-        className="h-4 max-w-(--skeleton-width) flex-1"
+        className="h-5 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"
         style={
           {
@@ -686,10 +700,10 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-9 min-w-0 -translate-x-px items-center gap-3 overflow-hidden rounded-md px-3 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
-        size === "sm" && "text-xs",
-        size === "md" && "text-sm",
+        size === "sm" && "text-sm h-8",
+        size === "md" && "text-base h-9",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -709,6 +723,7 @@ export {
   SidebarHeader,
   SidebarInput,
   SidebarInset,
+  SidebarLogo,
   SidebarMenu,
   SidebarMenuAction,
   SidebarMenuBadge,

--- a/src/features/organization/attendees/components/AttendeesFilters.tsx
+++ b/src/features/organization/attendees/components/AttendeesFilters.tsx
@@ -107,6 +107,7 @@ export function AttendeesFilters({
         <Select
           defaultValue="name"
           onValueChange={(value) => setSearchType(value as "name" | "id")}
+          disabled
         >
           <SelectTrigger className="w-[90px] rounded-r-none focus:ring-0">
             <SelectValue />
@@ -120,10 +121,11 @@ export function AttendeesFilters({
         {/* Search Input Field */}
         <div className="relative w-full">
           <Input
-            placeholder={`Search by ${searchType}...`}
+            placeholder={`Search by ${searchType} coming soon...`}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="rounded-l-none pr-8"
+            disabled
           />
           {searchQuery && (
             <Button
@@ -132,6 +134,7 @@ export function AttendeesFilters({
               size="icon"
               className="absolute right-8 top-0 h-full"
               onClick={clearSearch}
+              disabled
             >
               <XIcon className="h-4 w-4" />
             </Button>
@@ -141,6 +144,7 @@ export function AttendeesFilters({
             variant="ghost"
             size="icon"
             className="absolute right-0 top-0 h-full"
+            disabled
           >
             <SearchIcon className="h-4 w-4" />
           </Button>

--- a/src/features/organization/dashboard/components/MobileMembersStats.tsx
+++ b/src/features/organization/dashboard/components/MobileMembersStats.tsx
@@ -297,13 +297,13 @@ export function MobileMembersStats({
                 <p className="text-xs lg:text-sm font-medium text-muted-foreground">
                   Total Students
                 </p>
-                <p className="text-lg lg:text-xl font-bold text-foreground">
+                <div className="text-lg lg:text-xl font-bold text-foreground">
                   {isLoading ? (
                     <Skeleton className="h-5 w-12 lg:h-6 lg:w-16" />
                   ) : (
                     studentStats.totalStudents.toLocaleString()
                   )}
-                </p>
+                </div>
               </div>
             </div>
           </CardContent>
@@ -320,13 +320,13 @@ export function MobileMembersStats({
                 <p className="text-xs lg:text-sm font-medium text-muted-foreground">
                   Total Events
                 </p>
-                <p className="text-lg lg:text-xl font-bold text-foreground">
+                <div className="text-lg lg:text-xl font-bold text-foreground">
                   {isLoading ? (
                     <Skeleton className="h-5 w-12 lg:h-6 lg:w-16" />
                   ) : (
                     studentStats.totalEvents.toLocaleString()
                   )}
-                </p>
+                </div>
               </div>
             </div>
           </CardContent>
@@ -343,13 +343,13 @@ export function MobileMembersStats({
                 <p className="text-xs lg:text-sm font-medium text-muted-foreground">
                   Total Attendances
                 </p>
-                <p className="text-lg lg:text-xl font-bold text-foreground">
+                <div className="text-lg lg:text-xl font-bold text-foreground">
                   {isLoading ? (
                     <Skeleton className="h-5 w-12 lg:h-6 lg:w-16" />
                   ) : (
                     studentStats.totalAttendances.toLocaleString()
                   )}
-                </p>
+                </div>
               </div>
             </div>
           </CardContent>
@@ -366,13 +366,13 @@ export function MobileMembersStats({
                 <p className="text-xs lg:text-sm font-medium text-muted-foreground">
                   Total Absences
                 </p>
-                <p className="text-lg lg:text-xl font-bold text-foreground">
+                <div className="text-lg lg:text-xl font-bold text-foreground">
                   {isLoading ? (
                     <Skeleton className="h-5 w-12 lg:h-6 lg:w-16" />
                   ) : (
                     studentStats.totalAbsences.toLocaleString()
                   )}
-                </p>
+                </div>
               </div>
             </div>
           </CardContent>

--- a/src/features/organization/log-attendance/components/AttendanceForm.tsx
+++ b/src/features/organization/log-attendance/components/AttendanceForm.tsx
@@ -393,7 +393,7 @@ export function AttendanceForm({
           </div>
 
           {/* Type Selection - Only show if both are available */}
-          {hasTimeIn && hasTimeOut && onTabChange && (
+          {/* {hasTimeIn && hasTimeOut && onTabChange && (
             <div className="mt-6 flex flex-wrap gap-2">
               <Button
                 variant={activeTab === "time-in" ? "default" : "outline"}
@@ -420,7 +420,7 @@ export function AttendanceForm({
                 Check-Out
               </Button>
             </div>
-          )}
+          )} */}
 
           {/* Current mode notice - reinforcement */}
           <div

--- a/src/features/organization/log-attendance/components/Search/SearchByNameForm.tsx
+++ b/src/features/organization/log-attendance/components/Search/SearchByNameForm.tsx
@@ -46,18 +46,20 @@ export function SearchByNameForm({
         <div className="flex flex-col sm:flex-row gap-2">
           <Input
             id="student-name"
-            placeholder="Start typing student name..."
+            placeholder="Search student by name coming soon..."
             value={searchName}
             onChange={(e) => setSearchName(e.target.value)}
             onKeyDown={handleKeyDown}
             className="flex-1"
-            disabled={isSubmitting}
+            // disabled={isSubmitting}
+            disabled
           />
           <Button
             type="button"
             onClick={handleSearch}
-            disabled={isSubmitting || isSearching || !searchName.trim()}
+            // disabled={isSubmitting || isSearching || !searchName.trim()}
             className="w-full sm:w-auto"
+            disabled
           >
             {isSearching ? (
               <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/src/features/organization/members/components/MembersHeader.tsx
+++ b/src/features/organization/members/components/MembersHeader.tsx
@@ -56,16 +56,19 @@ export function MembersHeader({
         >
           <Input
             type="search"
-            placeholder="Search members..."
+            placeholder="Search member coming soon..."
             className="w-full pr-10"
             value={searchTerm}
             onChange={handleSearchChange}
+            disabled
+            title="Search feature is coming soon"
           />
           <Button
             type="submit"
             variant="ghost"
             size="sm"
             className="absolute right-0 top-0 h-full px-3"
+            disabled
           >
             <Search className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
## Summary
This PR introduces minor UI refinements to improve clarity, readability, and frontend stability

## Changes Made
- Improved sidebar typography and spacing for better readability and visual harmony-- emphasizing simplicity and ease of use
- Disabled search inputs for "name" fields to avoid unused/unsupported functionality
- Removed unused "Reports" and "Settings" items from the sidebar
- Optimized MobileMembersStats code to prevent potential hydration issues

## Screenshots
### Desktop and Mobile Sidebar
### Original
<table>
  <tr>
    <td><strong>Mobile</strong></td>
    <td><strong>Desktop</strong></td>
  </tr>
  <tr>
    <td>
    <img height="400" alt="Mobile" src="https://github.com/user-attachments/assets/3421bdf3-2f46-411b-a536-731f6248fd9b" />  
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/8862ffc2-8381-4881-84e5-8c2b04b0e8eb" 
           alt="Desktop" 
           height="400" />
    </td>
  </tr>
</table>

### Revised
<table>
  <tr>
    <td><strong>Mobile</strong></td>
    <td><strong>Desktop</strong></td>
  </tr>
  <tr>
    <td>
    <img src="https://github.com/user-attachments/assets/21fe17a3-9273-4945-8594-c2e01aa07e29" 
           alt="Mobile" 
           height="400" />
    </td>
    <td>
      <img height="400" alt="Desktop" src="https://github.com/user-attachments/assets/4b85c2f4-267f-4ea3-ab4d-247dee63ce73" />
    </td>
  </tr>
</table>

